### PR TITLE
Add Deno starter server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # JackCraftCode.github.io
-My personal portfolio website
+
+This is the source for my personal portfolio. The site uses [Deno](https://deno.land/) and is designed to run on Deno Deploy.
+
+## Running locally
+
+Make sure you have Deno installed, then run:
+
+```sh
+deno run --allow-read --allow-net main.ts
+```
+
+The root page serves `index.html`. Visiting `/projects` fetches the public repositories from GitHub.

--- a/index.html
+++ b/index.html
@@ -1,7 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>JackCraftCode Portfolio</title>
+</head>
 <body>
-<h1>Hello World</h1>
-<p>I'm hosted with GitHub Pages.</p>
+  <h1>Hello, I'm JackCraftCode!</h1>
+  <p>Welcome to my portfolio site powered by <strong>Deno</strong>.</p>
+  <p><a href="/projects">See my GitHub projects</a></p>
 </body>
 </html>

--- a/main.ts
+++ b/main.ts
@@ -1,0 +1,18 @@
+import { serve } from "https://deno.land/std@0.204.0/http/server.ts";
+
+const indexHtml = await Deno.readTextFile("./index.html");
+
+serve(async (req) => {
+  const url = new URL(req.url);
+  if (url.pathname === "/projects") {
+    const api = "https://api.github.com/users/JackCraftCode/repos";
+    const resp = await fetch(api);
+    const repos = await resp.json();
+    return new Response(JSON.stringify(repos, null, 2), {
+      headers: { "content-type": "application/json" },
+    });
+  }
+  return new Response(indexHtml, {
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+});


### PR DESCRIPTION
## Summary
- create a basic Deno server in `main.ts`
- flesh out `index.html` with a simple layout and link to `/projects`
- document how to run the project locally with Deno

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684722a9076483219725ea29ef88beb5